### PR TITLE
Fix: Mettre "test2" dans le fichier test2.txt

### DIFF
--- a/test2.txt
+++ b/test2.txt
@@ -1,1 +1,1 @@
-Contenu du fichier test2.txt créé par Claude.
+test2


### PR DESCRIPTION
Ce PR résout l'issue #2 en mettant à jour le contenu du fichier test2.txt.

Le fichier contient maintenant uniquement la chaîne de caractères "test2" comme demandé.

Closes #2