### PR TITLE
Ajout d'un fichier .gitignore pour IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Intellij IDEA
+.idea/
+out/
+*.iml
+
+# Compiled class files
+*.class
+
+# Log files
+*.log
+
+# Package files
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs
+hs_err_pid*


### PR DESCRIPTION
Ce PR ajoute un fichier .gitignore pour configurer correctement les projets IntelliJ IDEA.

Le fichier ignore les éléments suivants :
- Le répertoire `.idea/` (configuration de l'IDE)
- Le répertoire `out/` (fichiers de sortie de compilation)
- Les fichiers `*.iml` (fichiers de module IntelliJ)

J'ai aussi ajouté quelques règles standard pour ignorer les fichiers classiques de Java (fichiers .class, .jar, logs, etc.).